### PR TITLE
Fix website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spilled.ink
 
-[Spilled.ink](spilled.ink) is a new take on open source email infrastructure.
+[Spilled.ink](https://spilled.ink) is a new take on open source email infrastructure.
 
 This repository contains the spilld SMTP and IMAP server,
 built around a new SQLite-based storage format, spillbox.


### PR DESCRIPTION
Currently it redirects to the non-existent file https://github.com/spilled-ink/spilld/blob/master/spilled.ink